### PR TITLE
Update dead link of online handbook documentation.md

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -42,7 +42,7 @@ navigation_weight: 5
 [ft2-manual]: {% link docs/FT2.pdf %}
 [techniques-of-chipping]: {% link docs/Vhiiula-TechniquesOfChipping.txt %}
 [trackers-handbook-html]: {% link docs/TrackersHandbook05.zip %}
-[trackers-handbook-online]: http://www.modplug.com/mods/handbook/handbook.htm
+[trackers-handbook-online]: https://resources.openmpt.org/tracker_handbook/handbook.htm
 [trackers-handbook-text]: {% link docs/TrackersHandbook05.txt.zip %}
 [tracking-principles]: {% link docs/Tracking Principles.html %}
 [trax-weekly]: {% link docs/TraxWeekly.zip %}


### PR DESCRIPTION
Hi. The old link pointing to modplug looks like it does not exist anymore.
Through the web archive it is possible to  find this new link. 
For a period of time the old link used to return HTTP 301 with the new location at https://resources.openmpt.org/tracker_handbook/handbook.htm
This new link looks alive and seems to host the same content